### PR TITLE
Add component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,34 @@
+{
+  "name": "backbone.wreqr",
+  "description": "A Simple Service Bus For Backbone and Backbone.Marionette",
+  "version": "0.2.0",
+  "repo": "marionettejs/backbone.wreqr",
+  "keywords": [
+    "backbone",
+    "plugin",
+    "computed",
+    "field",
+    "model",
+    "client",
+    "browser"
+  ],
+  "license":  "MIT",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/marionettejs/backbone.wreqr/blob/master/LICENSE.md"
+    }
+  ],
+  "author": {
+    "name": "Derick Bailey",
+    "email": "marionettejs@gmail.com",
+    "web": "http://derickbailey.lostechies.com"
+  },
+  "dependencies": {
+    "jashkenas/backbone": "*"
+  },
+  "main": "lib/amd/backbone.wreqr.js",
+  "scripts": [
+    "lib/amd/backbone.wreqr.js" 
+  ]
+}


### PR DESCRIPTION
see https://github.com/marionettejs/backbone.marionette/pull/882

Problem is that jquery cannot be installed via component, afaik...
Shouldn't there already be a jquery instance on the page if you're using backbone? (I copied the dependencies from package.json)
