### PR TITLE
Clean up dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "github": "https://github.com/marionettejs/backbone.wreqr",
 
   "dependencies": {
-    "jquery": "~1.8.3",
-    "backbone": "~1.0.0"
+    "backbone": ">=0.9.9 <=1.1.2",
+    "underscore": ">=1.3.3 <=1.6.0"
   },
   "devDependencies": {
     "grunt": "0.4.0",


### PR DESCRIPTION
This removes an unnecessary and outdated jquery dependency, since jquery is never used directly by this module (e.g. `require('jquery')`) and [is optional](https://github.com/jashkenas/backbone/issues/2997).

It also loosens the backbone requirement to be more in line with Marionette's advertised requirements and the requirement in the jam section of the config. Previously, browserifying marionette.js would pull in multiple versions of backbone to meet marionette's backbone requirement (~1.1.0) and this one, which was incompatible.

Also adds a hard dependency on underscore greater than the version used in tests (1.3.3+), since it is referenced directly (`require('underscore')`).

The tests continue to pass.
