### PR TITLE
Reqres/Commands now support any handler

### DIFF
--- a/spec/javascripts/commands.spec.js
+++ b/spec/javascripts/commands.spec.js
@@ -1,20 +1,35 @@
 describe("commands", function(){
-
   describe("when executing a command", function(){
     var commands, result;
 
-    beforeEach(function(){
-      commands = new Wreqr.Commands();
+    describe("and the handler is a function", function() {
+      beforeEach(function(){
+        commands = new Wreqr.Commands();
 
-      commands.setHandler("do:it", function(){
-        return "some value";
+        commands.setHandler("do:it", function(){
+          return "some value";
+        });
+
+        result = commands.execute("do:it");
       });
 
-      result = commands.execute("do:it");
+      it("should not return any value", function(){
+        expect(result).toBeUndefined();
+      });
     });
 
-    it("should not return any value", function(){
-      expect(result).toBeUndefined();
+    describe("and the handler is not a function", function() {
+      beforeEach(function(){
+        commands = new Wreqr.Commands();
+
+        commands.setHandler("do:it", "someValue");
+
+        result = commands.execute("do:it");
+      });
+
+      it("should not return a value", function(){
+        expect(result).toBeUndefined();
+      });
     });
   });
 

--- a/spec/javascripts/handlers.setFromHash.spec.js
+++ b/spec/javascripts/handlers.setFromHash.spec.js
@@ -35,7 +35,7 @@ describe("handler - set from hash", function(){
       
       hndlrs = {
         "foo": {
-          callback: jasmine.createSpy("foo handler"),
+          handler: jasmine.createSpy("foo handler"),
           context: ctx
         }
       };
@@ -47,8 +47,8 @@ describe("handler - set from hash", function(){
     });
 
     it("should execute the handler callback with the specified context", function(){
-      expect(hndlrs.foo.callback).toHaveBeenCalled();
-      expect(hndlrs.foo.callback.mostRecentCall.object).toBe(ctx);
+      expect(hndlrs.foo.handler).toHaveBeenCalled();
+      expect(hndlrs.foo.handler.mostRecentCall.object).toBe(ctx);
     });
   });
 

--- a/spec/javascripts/requestResponse.spec.js
+++ b/spec/javascripts/requestResponse.spec.js
@@ -1,20 +1,35 @@
 describe("request/response", function(){
-
   describe("when requesting a response", function(){
     var reqres, result;
 
-    beforeEach(function(){
-      reqres = new Wreqr.RequestResponse();
+    describe("with a function as a handler", function() {
+      beforeEach(function(){
+        reqres = new Wreqr.RequestResponse();
 
-      reqres.setHandler("do:it", function(){
-        return "some value";
+        reqres.setHandler("do:it", function(){
+          return "some value";
+        });
+
+        result = reqres.request("do:it");
       });
 
-      result = reqres.request("do:it");
+      it("should return a value", function(){
+        expect(result).toBe("some value");
+      });
     });
 
-    it("should return a value", function(){
-      expect(result).toBe("some value");
+    describe("with a value as a handler", function() {
+      beforeEach(function(){
+        reqres = new Wreqr.RequestResponse();
+
+        reqres.setHandler("do:it", "someValue");
+
+        result = reqres.request("do:it");
+      });
+
+      it("should return the value", function(){
+        expect(result).toBe("someValue");
+      });
     });
   });
 

--- a/src/wreqr.commands.js
+++ b/src/wreqr.commands.js
@@ -26,7 +26,7 @@ Wreqr.Commands = (function(Wreqr){
       args = Array.prototype.slice.call(arguments, 1);
 
       if (this.hasHandler(name)){
-        this.getHandler(name).apply(this, args);
+        this._triggerHandler.apply(this, arguments);
       } else {
         this.storage.addCommand(name, args);
       }
@@ -39,7 +39,9 @@ Wreqr.Commands = (function(Wreqr){
 
       // loop through and execute all the stored command instances
       _.each(command.instances, function(args){
-        handler.apply(context, args);
+        if (_.isFunction(handler)) {
+          handler.apply(context, args);
+        }
       });
 
       this.storage.clearCommands(name);

--- a/src/wreqr.handlers.js
+++ b/src/wreqr.handlers.js
@@ -31,7 +31,7 @@ Wreqr.Handlers = (function(Backbone, _){
 
         if (_.isObject(handler) && !_.isFunction(handler)){
           context = handler.context;
-          handler = handler.callback;
+          handler = handler.handler;
         }
 
         this.setHandler(name, handler, context);
@@ -42,7 +42,7 @@ Wreqr.Handlers = (function(Backbone, _){
     // optional context to run the handler within
     setHandler: function(name, handler, context){
       var config = {
-        callback: handler,
+        handler: handler,
         context: context
       };
 
@@ -66,10 +66,15 @@ Wreqr.Handlers = (function(Backbone, _){
         return;
       }
 
-      return function(){
-        var args = Array.prototype.slice.apply(arguments);
-        return config.callback.apply(config.context, args);
-      };
+      if (_.isFunction(config.handler)) {
+        return function(){
+          var args = Array.prototype.slice.apply(arguments);
+          return config.handler.apply(config.context, args);
+        };
+      } else {
+        return config.handler;
+      }
+      
     },
 
     // Remove a handler for the specified name
@@ -80,7 +85,20 @@ Wreqr.Handlers = (function(Backbone, _){
     // Remove all handlers from this registry
     removeAllHandlers: function(){
       this._wreqrHandlers = {};
+    },
+
+    // If the handler is a function, execute it with the args
+    // Otherwise, just return it
+    _triggerHandler: function(name) {
+      var args = Array.prototype.slice.call(arguments, 1);
+      var handler = this.getHandler(name);
+      if (_.isFunction(handler)) {
+        return handler.apply(this, args);
+      } else {
+        return handler;
+      }
     }
+
   });
 
   return Handlers;

--- a/src/wreqr.requestresponse.js
+++ b/src/wreqr.requestresponse.js
@@ -7,11 +7,9 @@ Wreqr.RequestResponse = (function(Wreqr){
   "use strict";
 
   return Wreqr.Handlers.extend({
-    request: function(){
-      var name = arguments[0];
-      var args = Array.prototype.slice.call(arguments, 1);
+    request: function(name){
       if (this.hasHandler(name)) {
-        return this.getHandler(name).apply(this, args);
+        return this._triggerHandler.apply(this, arguments);
       }
     }
   });


### PR DESCRIPTION
This allows you to write

``` js
reqres.setHandler('myName', 'Jmeas');
```

instead of

``` js
reqres.setHandler('myName', function() {
  return 'Jmeas';
});
```
