### PR TITLE
reqres request's aren't receiving return data from the handler

### DIFF
--- a/spec/javascripts/radio/reqres.spec.js
+++ b/spec/javascripts/radio/reqres.spec.js
@@ -157,4 +157,28 @@ describe('radio.reqres', function() {
     });
 
   });
+
+  describe('passing data between the handler and the request', function() {
+
+    var ch, chName, fn, returnObject;
+
+    beforeEach(function() {
+
+      chName = 'test';
+      reqName = 'some:request';
+      fn = function(p1, p2, p3){
+        return p1 + p2 +p3;
+      };
+      Wreqr.radio.reqres.setHandler( chName, reqName, fn );
+
+      returnObject = Wreqr.radio.reqres.request( chName, reqName , 1, 2, 3);
+
+    });
+
+    it( 'should pass parameters to handler from request', function() {
+      expect( returnObject ).toEqual(6);
+    });
+
+  });
+
 })

--- a/src/wreqr.radio.js
+++ b/src/wreqr.radio.js
@@ -77,7 +77,7 @@ Wreqr.radio = (function(Wreqr){
       var messageSystem = radio._getChannel(channelName)[system];
       var args = Array.prototype.slice.call(arguments, 1);
 
-      messageSystem[method].apply(messageSystem, args);
+      return messageSystem[method].apply(messageSystem, args);
     };
   };
 


### PR DESCRIPTION
This pull request fixes the below case.

```

Wreqr.radio.reqres.setHandler('testing', 'someRequest', function(){return 'it works!' } );
var retValue =  Wreqr.radio.reqres.request( 'testing', 'someRequest');

alert(retValue === 'it works!')

```
