### PR TITLE
Allow setHandlers to set the context for each handler not explicitly set

### DIFF
--- a/src/wreqr.handlers.js
+++ b/src/wreqr.handlers.js
@@ -25,16 +25,16 @@ Wreqr.Handlers = (function(Backbone, _){
   _.extend(Handlers.prototype, Backbone.Events, {
 
     // Add multiple handlers using an object literal configuration
-    setHandlers: function(handlers){
+    setHandlers: function(handlers, context){
       _.each(handlers, function(handler, name){
-        var context = null;
+        var handlerContext = context;
 
         if (_.isObject(handler) && !_.isFunction(handler)){
-          context = handler.context;
+          handlerContext = handler.context;
           handler = handler.callback;
         }
 
-        this.setHandler(name, handler, context);
+        this.setHandler(name, handler, handlerContext);
       }, this);
     },
 


### PR DESCRIPTION
Allows for:

``` javascript
App.vent.setHandlers({
  'get:foo': this.getFoo,
  'get:bar': this.getBar
}, this);
```

Instead of:

``` Javascript
App.vent.setHandlers({
  'get:foo': {
    handler: this.getFoo,
    context: this
  },
  'get:bar': {
    handler: this.getBar,
    context: this
  }
});
```
