### PR TITLE
Bump backbone dependency range

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "model"
   ],
   "dependencies": {
-    "backbone": ">=0.9.9 <=1.3.2",
+    "backbone": ">=0.9.9 <=1.3.x",
     "underscore": ">=1.3.3 <=1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "github": "https://github.com/marionettejs/backbone.wreqr",
   "dependencies": {
-    "backbone": ">=0.9.9 <=1.3.3",
+    "backbone": ">=0.9.9 <=1.3.x",
     "underscore": ">=1.3.3 <=1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "github": "https://github.com/marionettejs/backbone.wreqr",
   "dependencies": {
-    "backbone": ">=0.9.9 <=1.3.2",
+    "backbone": ">=0.9.9 <=1.3.3",
     "underscore": ">=1.3.3 <=1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps the dependency range for `backbone` to include `1.3.3` which resolves #80 